### PR TITLE
feat: add regex pattern for custom cdn urls

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,13 @@ export const cdnUrl = 'https://cdn.sanity.io'
  */
 export const cdnUrlPattern = /^https:\/\/cdn\.sanity\./
 
+
+/**
+ * @internal
+ */
+export const customCdnUrlPattern = /^https:\/\/cdn\.[^/]+\/(images|files)\/[^/]+\/.*?[a-zA-Z0-9_]{24,40}.*$/
+
+
 /**
  * @internal
  */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,12 +8,11 @@ export const cdnUrl = 'https://cdn.sanity.io'
  */
 export const cdnUrlPattern = /^https:\/\/cdn\.sanity\./
 
-
 /**
  * @internal
  */
-export const customCdnUrlPattern = /^https:\/\/cdn\.[^/]+\/(images|files)\/[^/]+\/.*?[a-zA-Z0-9_]{24,40}.*$/
-
+export const customCdnUrlPattern =
+  /^https:\/\/cdn\.[^/]+\/(images|files)\/[^/]+\/.*?[a-zA-Z0-9_]{24,40}.*$/
 
 /**
  * @internal

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,5 +1,6 @@
 import {
   cdnUrlPattern,
+  customCdnUrlPattern,
   fileAssetIdPattern,
   imageAssetFilenamePattern,
   imageAssetIdPattern,
@@ -116,7 +117,7 @@ export function parseAssetFilename(filename: string): SanityAssetIdParts {
  * @throws If URL is invalid or not a Sanity asset URL
  */
 export function parseAssetUrl(url: string): SanityAssetUrlParts {
-  if (!cdnUrlPattern.test(url)) {
+  if (!(cdnUrlPattern.test(url) || customCdnUrlPattern.test(url))) {
     throw new Error(`URL is not a valid Sanity asset URL: ${url}`)
   }
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -117,7 +117,7 @@ export function parseAssetFilename(filename: string): SanityAssetIdParts {
  * @throws If URL is invalid or not a Sanity asset URL
  */
 export function parseAssetUrl(url: string): SanityAssetUrlParts {
-  if (!(cdnUrlPattern.test(url) || customCdnUrlPattern.test(url))) {
+  if (!cdnUrlPattern.test(url) && !customCdnUrlPattern.test(url)) {
     throw new Error(`URL is not a valid Sanity asset URL: ${url}`)
   }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -2,6 +2,7 @@ import {isAssetObjectStub, isAssetPathStub, isAssetUrlStub, isReference} from '.
 import {
   cdnUrl,
   cdnUrlPattern,
+  customCdnUrlPattern,
   fileAssetFilenamePattern,
   imageAssetFilenamePattern,
   pathPattern,
@@ -157,7 +158,7 @@ export function getUrlPath(url: string): string {
     return url
   }
 
-  if (!cdnUrlPattern.test(url)) {
+  if (!(cdnUrlPattern.test(url) || customCdnUrlPattern.test(url))) {
     throw new UnresolvableError(`Failed to resolve path from URL "${url}"`)
   }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -158,7 +158,7 @@ export function getUrlPath(url: string): string {
     return url
   }
 
-  if (!(cdnUrlPattern.test(url) || customCdnUrlPattern.test(url))) {
+  if (!cdnUrlPattern.test(url) && !customCdnUrlPattern.test(url)) {
     throw new UnresolvableError(`Failed to resolve path from URL "${url}"`)
   }
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -112,6 +112,7 @@ test('parseAssetFilename(): returns object of named image properties if legacy f
 test.each([
   'https://cdn.sanity.io/images/espenhov/diary/756e4bd9c0a04ada3d3cc396cf81f1c433b07870-5760x3840.jpg/vanity-filename.jpg',
   'https://cdn.sanity.staging/images/espenhov/diary/756e4bd9c0a04ada3d3cc396cf81f1c433b07870-5760x3840.jpg/vanity-filename.jpg',
+  'https://cdn.autofoos.com/images/espenhov/diary/756e4bd9c0a04ada3d3cc396cf81f1c433b07870-5760x3840.jpg/vanity-filename.jpg',
 ])(
   'parseAssetUrl(): returns object of named image properties on modern filename with vanity filename',
   (url) => {
@@ -131,6 +132,7 @@ test.each([
 test.each([
   'https://cdn.sanity.io/images/espenhov/diary/756e4bd9c0a04ada3d3cc396cf81f1c433b07870-5760x3840.jpg',
   'https://cdn.sanity.staging/images/espenhov/diary/756e4bd9c0a04ada3d3cc396cf81f1c433b07870-5760x3840.jpg',
+  'https://cdn.autofoos.com/images/espenhov/diary/756e4bd9c0a04ada3d3cc396cf81f1c433b07870-5760x3840.jpg',
 ])('parseAssetUrl(): returns object of named image properties on modern filename', (url) => {
   expect(parseAssetUrl(url)).toMatchObject({
     assetId: '756e4bd9c0a04ada3d3cc396cf81f1c433b07870',
@@ -147,6 +149,7 @@ test.each([
 test.each([
   'https://cdn.sanity.io/images/espenhov/diary/LA5zSofUOP0i_iQwi4B2dEbzHQseitcuORm4n-600x578.png',
   'https://cdn.sanity.staging/images/espenhov/diary/LA5zSofUOP0i_iQwi4B2dEbzHQseitcuORm4n-600x578.png',
+  'https://cdn.autofoos.com/images/espenhov/diary/LA5zSofUOP0i_iQwi4B2dEbzHQseitcuORm4n-600x578.png',
 ])('parseAssetUrl(): returns object of named image properties on legacy filename', (url) => {
   expect(parseAssetUrl(url)).toMatchObject({
     assetId: 'LA5zSofUOP0i_iQwi4B2dEbzHQseitcuORm4n',
@@ -163,6 +166,7 @@ test.each([
 test.each([
   'https://cdn.sanity.io/files/espenhov/diary/ae0ef9f916843d32fef3faffb9a675d4cce046f0.pdf/oslo-guide.pdf',
   'https://cdn.sanity.staging/files/espenhov/diary/ae0ef9f916843d32fef3faffb9a675d4cce046f0.pdf/oslo-guide.pdf',
+  'https://cdn.autofoos.com/files/espenhov/diary/ae0ef9f916843d32fef3faffb9a675d4cce046f0.pdf/oslo-guide.pdf',
 ])(
   'parseAssetUrl(): returns object of named file properties on modern filename with vanity filename',
   (url) => {
@@ -180,6 +184,7 @@ test.each([
 test.each([
   'https://cdn.sanity.io/files/espenhov/diary/ae0ef9f916843d32fef3faffb9a675d4cce046f0.pdf',
   'https://cdn.sanity.staging/files/espenhov/diary/ae0ef9f916843d32fef3faffb9a675d4cce046f0.pdf',
+  'https://cdn.autofoos.com/files/espenhov/diary/ae0ef9f916843d32fef3faffb9a675d4cce046f0.pdf',
 ])('parseAssetUrl(): returns object of named file properties on modern filename', (url) => {
   expect(parseAssetUrl(url)).toMatchObject({
     assetId: 'ae0ef9f916843d32fef3faffb9a675d4cce046f0',
@@ -194,6 +199,7 @@ test.each([
 test.each([
   'https://cdn.sanity.io/files/espenhov/diary/LA5zSofUOP0i_iQwi4B2dEbzHQseitcuORm4n.pdf',
   'https://cdn.sanity.staging/files/espenhov/diary/LA5zSofUOP0i_iQwi4B2dEbzHQseitcuORm4n.pdf',
+  'https://cdn.autofoos.com/files/espenhov/diary/LA5zSofUOP0i_iQwi4B2dEbzHQseitcuORm4n.pdf',
 ])('parseAssetUrl(): returns object of named file properties on legacy filename', (url) => {
   expect(parseAssetUrl(url)).toMatchObject({
     assetId: 'LA5zSofUOP0i_iQwi4B2dEbzHQseitcuORm4n',

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -86,7 +86,7 @@ const validLegacyImgSources: [string, SanityImageSource][] = [
   ['object path stub (pretty filename)', {asset: {path: imgLegacyPathPretty}}],
   ['object url stub (pretty filename)', {asset: {url: imgLegacyUrlPretty}}],
   ['staging object url stub (pretty filename)', {asset: {url: stagingImgLegacyUrlPretty}}],
-  ['cusom cdn object url stub (pretty filename)', {asset: {url: customCdnImgLegacyUrlPretty}}],
+  ['custom cdn object url stub (pretty filename)', {asset: {url: customCdnImgLegacyUrlPretty}}],
 ]
 
 const fileId = 'file-def987abc12345678909877654321abcdef98765-pdf'

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -36,6 +36,8 @@ const imgPathPretty = `${imgPath}/pretty.png`
 const imgUrlPretty = `${imgUrl}/pretty.png`
 const stagingImgUrl = `https://cdn.sanity.staging/${imgPath}`
 const stagingImgUrlPretty = `${stagingImgUrl}/pretty.png`
+const customCdnImgUrl = `https://cdn.autofoos.com/${imgPath}`
+const customCdnImgUrlPretty = `${customCdnImgUrl}/pretty.png`
 const validImgSources: [string, SanityImageSource][] = [
   ['asset id', imgId],
   ['reference', {_ref: imgId}],
@@ -47,12 +49,14 @@ const validImgSources: [string, SanityImageSource][] = [
   ['object path stub', {asset: {path: imgPath}}],
   ['object url stub', {asset: {url: imgUrl}}],
   ['staging object url stub', {asset: {url: stagingImgUrl}}],
+  ['custom cdn object url stub', {asset: {url: customCdnImgUrl}}],
   ['path stub (pretty filename)', {path: imgPathPretty}],
   ['url stub (pretty filename)', {url: imgUrlPretty}],
   ['staging url stub (pretty filename)', {url: stagingImgUrlPretty}],
   ['object path stub (pretty filename)', {asset: {path: imgPathPretty}}],
   ['object url stub (pretty filename)', {asset: {url: imgUrlPretty}}],
   ['staging object url stub (pretty filename)', {asset: {url: stagingImgUrlPretty}}],
+  ['custom cdn object url stub (pretty filename)', {asset: {url: customCdnImgUrlPretty}}],
 ]
 
 const imgLegacyId = 'image-LA5zSofUOP0i_iQwi4B2dEbzHQseitcuORm4n-600x578-png'
@@ -62,6 +66,8 @@ const imgLegacyPathPretty = `${imgLegacyPath}/pretty.png`
 const imgLegacyUrlPretty = `${imgLegacyUrl}/pretty.png`
 const stagingImgLegacyUrl = `https://cdn.sanity.io/${imgLegacyPath}`
 const stagingImgLegacyUrlPretty = `${stagingImgLegacyUrl}/pretty.png`
+const customCdnImgLegacyUrl = `https://cdn.autofoos.com/${imgLegacyPath}`
+const customCdnImgLegacyUrlPretty = `${customCdnImgLegacyUrl}/pretty.png`
 const validLegacyImgSources: [string, SanityImageSource][] = [
   ['asset id', imgLegacyId],
   ['reference', {_ref: imgLegacyId}],
@@ -73,12 +79,14 @@ const validLegacyImgSources: [string, SanityImageSource][] = [
   ['object path stub', {asset: {path: imgLegacyPath}}],
   ['object url stub', {asset: {url: imgLegacyUrl}}],
   ['staging object url stub', {asset: {url: stagingImgLegacyUrl}}],
+  ['custom cdn object url stub', {asset: {url: customCdnImgLegacyUrl}}],
   ['path stub (pretty filename)', {path: imgLegacyPathPretty}],
   ['url stub (pretty filename)', {url: imgLegacyUrlPretty}],
   ['staging url stub (pretty filename)', {url: stagingImgLegacyUrlPretty}],
   ['object path stub (pretty filename)', {asset: {path: imgLegacyPathPretty}}],
   ['object url stub (pretty filename)', {asset: {url: imgLegacyUrlPretty}}],
   ['staging object url stub (pretty filename)', {asset: {url: stagingImgLegacyUrlPretty}}],
+  ['cusom cdn object url stub (pretty filename)', {asset: {url: customCdnImgLegacyUrlPretty}}],
 ]
 
 const fileId = 'file-def987abc12345678909877654321abcdef98765-pdf'
@@ -88,6 +96,8 @@ const filePathPretty = `${filePath}/pretty.pdf`
 const fileUrlPretty = `${fileUrl}/pretty.pdf`
 const stagingFileUrl = `https://cdn.sanity.staging/${filePath}`
 const stagingFileUrlPretty = `${stagingFileUrl}/pretty.pdf`
+const customCdnFileUrl = `https://cdn.autofoos.com/${filePath}`
+const customCdnFileUrlPretty = `${customCdnFileUrl}/pretty.pdf`
 const validFileSources: [string, SanityFileSource][] = [
   ['asset id', fileId],
   ['reference', {_ref: fileId}],
@@ -99,12 +109,14 @@ const validFileSources: [string, SanityFileSource][] = [
   ['object path stub', {asset: {path: filePath}}],
   ['object url stub', {asset: {url: fileUrl}}],
   ['staging object url stub', {asset: {url: stagingFileUrl}}],
+  ['custom cdn object url stub', {asset: {url: customCdnFileUrl}}],
   ['path stub (pretty filename)', {path: filePathPretty}],
   ['url stub (pretty filename)', {url: fileUrlPretty}],
   ['staging url stub (pretty filename)', {url: stagingFileUrlPretty}],
   ['object path stub (pretty filename)', {asset: {path: filePathPretty}}],
   ['object url stub (pretty filename)', {asset: {url: fileUrlPretty}}],
   ['staging object url stub (pretty filename)', {asset: {url: stagingFileUrlPretty}}],
+  ['custom cdn object url stub (pretty filename)', {asset: {url: customCdnFileUrlPretty}}],
 ]
 
 // buildImagePath()


### PR DESCRIPTION
Studios that are connected to projects with custom CDNs are currently experiencing some broken behavior around image selection (for example: https://www.autofoos.com/structure/player;a1b3019b-a0e0-49d5-8212-9d85b9661202), and the attached GIF:
![2024-11-14 11 34 53](https://github.com/user-attachments/assets/1dfa2e31-c315-4fc5-97ac-ee93cbb1eff5)

This was caused by a recent PR in studio that uses asset-utils to get image dimensions here: https://github.com/sanity-io/sanity/pull/7535

This PR adds some affordances to help asset-utils pass checks that include custom CDN domains for assets.

Regex is expensive, performance-wise, and I've done my best to keep the regex for this check relatively strict but not too excessive, and to ensure we don't run the lengthier regex unless we absolutely need to.

In addition to adding the custom CDN to the relevant tests, I also ran some performance metrics which do not seem to indicate much of a performance hit, and things seem all right. But please let me know if you'd prefer additional tests (for example, to check wild URLs that fit _some_ parts of the regex pattern)

```
Without custom CDN check (just Sanity URLs):
┌───────────────────┬──────────┐
│ parseAssetUrl     │ Values   │
├───────────────────┼──────────┤
│ Average Time (ms) │ '0.0075' │
│ Max Time (ms)     │ '0.4439' │
│ Total Executions  │ 3000     │
└───────────────────┴──────────┘

┌───────────────────┬──────────┐
│ getAssetPath      │ Values   │
├───────────────────┼──────────┤
│ Average Time (ms) │ '0.0005' │
│ Max Time (ms)     │ '0.0094' │
│ Total Executions  │ 3000     │
└───────────────────┴──────────┘

With (just Sanity URLs):
┌───────────────────┬──────────┐
│ parseAssetUrl     │ Values   │
├───────────────────┼──────────┤
│ Average Time (ms) │ '0.0079' │
│ Max Time (ms)     │ '0.4661' │
│ Total Executions  │ 3000     │
└───────────────────┴──────────┘

┌───────────────────┬──────────┐
│ getAssetPath      │ Values   │
├───────────────────┼──────────┤
│ Average Time (ms) │ '0.0005' │
│ Max Time (ms)     │ '0.0080' │
│ Total Executions  │ 3000     │
└───────────────────┴──────────┘


With (including custom domains):
┌───────────────────┬──────────┐
│ parseAssetUrl     │ Values   │
├───────────────────┼──────────┤
│ Average Time (ms) │ '0.0059' │
│ Max Time (ms)     │ '0.5073' │
│ Total Executions  │ 3000     │
└───────────────────┴──────────┘

┌───────────────────┬──────────┐
│ getAssetPath      │ Values   │
├───────────────────┼──────────┤
│ Average Time (ms) │ '0.0005' │
│ Max Time (ms)     │ '0.0388' │
│ Total Executions  │ 3000     │
└───────────────────┴──────────┘


```