### PR TITLE
fix: support custom CDNs in `getIdFromString`

### DIFF
--- a/src/asserters.ts
+++ b/src/asserters.ts
@@ -1,4 +1,9 @@
-import {fileAssetIdPattern, imageAssetIdPattern} from './constants.js'
+import {
+  cdnUrlPattern,
+  customCdnUrlPattern,
+  fileAssetIdPattern,
+  imageAssetIdPattern,
+} from './constants.js'
 import type {
   SanityAssetIdStub,
   SanityAssetObjectStub,
@@ -125,4 +130,16 @@ export function isAssetId(documentId: string): boolean {
 export function isAssetObjectStub(stub: unknown): stub is SanityAssetObjectStub {
   const item = stub as SanityAssetObjectStub
   return isObject(item) && item.asset && typeof item.asset === 'object'
+}
+
+/**
+ * Checks whether or not the given URL is a valid Sanity CDN URL or what appears to be a valid
+ * custom CDN URL (has to be prefixed with `cdn.`, and follow the same path pattern as Sanity CDN )
+ *
+ * @param url - URL to check
+ * @returns True if Sanity CDN URL/Custom CDN URL, false otherwise
+ * @internal
+ */
+export function isCdnUrl(url: string): boolean {
+  return cdnUrlPattern.test(url) || customCdnUrlPattern.test(url)
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,6 +1,5 @@
+import {isCdnUrl} from './asserters.js'
 import {
-  cdnUrlPattern,
-  customCdnUrlPattern,
   fileAssetIdPattern,
   imageAssetFilenamePattern,
   imageAssetIdPattern,
@@ -117,7 +116,7 @@ export function parseAssetFilename(filename: string): SanityAssetIdParts {
  * @throws If URL is invalid or not a Sanity asset URL
  */
 export function parseAssetUrl(url: string): SanityAssetUrlParts {
-  if (!cdnUrlPattern.test(url) && !customCdnUrlPattern.test(url)) {
+  if (!isCdnUrl(url)) {
     throw new Error(`URL is not a valid Sanity asset URL: ${url}`)
   }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,8 +1,12 @@
-import {isAssetObjectStub, isAssetPathStub, isAssetUrlStub, isReference} from './asserters.js'
+import {
+  isAssetObjectStub,
+  isAssetPathStub,
+  isAssetUrlStub,
+  isCdnUrl,
+  isReference,
+} from './asserters.js'
 import {
   cdnUrl,
-  cdnUrlPattern,
-  customCdnUrlPattern,
   fileAssetFilenamePattern,
   imageAssetFilenamePattern,
   pathPattern,
@@ -158,7 +162,7 @@ export function getUrlPath(url: string): string {
     return url
   }
 
-  if (!cdnUrlPattern.test(url) && !customCdnUrlPattern.test(url)) {
+  if (!isCdnUrl(url)) {
     throw new UnresolvableError(`Failed to resolve path from URL "${url}"`)
   }
 

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -3,13 +3,13 @@ import {
   isAssetObjectStub,
   isAssetPathStub,
   isAssetUrlStub,
+  isCdnUrl,
   isReference,
   isSanityFileAsset,
   isSanityImageAsset,
 } from './asserters.js'
 import {
   cdnUrl,
-  cdnUrlPattern,
   dummyProject,
   fileAssetFilenamePattern,
   idPattern,
@@ -309,7 +309,7 @@ export function getIdFromString(str: string): string {
     return str
   }
 
-  const isAbsoluteUrl = cdnUrlPattern.test(str)
+  const isAbsoluteUrl = isCdnUrl(str)
   const path = isAbsoluteUrl ? new URL(str).pathname : str
 
   if (path.indexOf('/images') === 0 || path.indexOf('/files') === 0) {

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -465,6 +465,13 @@ test('getAssetDocumentId(): from URL (staging)', () => {
   expect(getAssetDocumentId(url)).toBe(id)
 })
 
+test('getAssetDocumentId(): from URL (custom cdn)', () => {
+  const id = 'image-9d884e501c64d640a321ca5700d32ac4250064ca-600x400-jpg'
+  const url =
+    'https://cdn.content.mydomain.com/images/foo/bar/9d884e501c64d640a321ca5700d32ac4250064ca-600x400.jpg'
+  expect(getAssetDocumentId(url)).toBe(id)
+})
+
 test('getAssetDocumentId(): from URL with pretty filename', () => {
   const id = 'image-f00baaf00baaf00baaf00baaf00baaf00baaf00b-320x240-png'
   const url =


### PR DESCRIPTION
There was another instance where we were only checking the Sanity CDN hostname - in the `getIdFromString` function. This rewrites all the CDN URL checks I could find to use a single new `isCdnUrl` asserter function.