### PR TITLE
feat: support file asset image preview id and filename patterns

### DIFF
--- a/.changeset/strange-apples-allow.md
+++ b/.changeset/strange-apples-allow.md
@@ -1,0 +1,6 @@
+---
+"@sanity/asset-utils": minor
+---
+
+Support file asset image preview patterns.
+

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,12 @@ export const fileAssetFilenamePattern = /^([a-zA-Z0-9_]{24,40}|[a-f0-9]{40})+\.[
 /**
  * @internal
  */
+export const filePreviewImageFilenamePattern =
+  /^([a-zA-Z0-9_]{24,40}|[a-f0-9]{40})-\d+x\d+-[a-z0-9]+\.([a-z0-9]+)$/
+
+/**
+ * @internal
+ */
 export const fileAssetIdPattern = /^file-([a-zA-Z0-9_]{24,40}|[a-f0-9]{40})+-[a-z0-9]+$/
 
 /**
@@ -33,6 +39,12 @@ export const imageAssetFilenamePattern = /^([a-zA-Z0-9_]{24,40}|[a-f0-9]{40})-\d
  * @internal
  */
 export const imageAssetIdPattern = /^image-([a-zA-Z0-9_]{24,40}|[a-f0-9]{40})+-\d+x\d+-[a-z0-9]+$/
+
+/**
+ * @internal
+ */
+export const filePreviewImageIdPattern =
+  /^image-([a-zA-Z0-9_]{24,40}|[a-f0-9]{40})+-\d+x\d+-[a-z0-9]+-[a-z0-9]+$/
 
 /**
  * @internal

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,6 +1,8 @@
 import {isCdnUrl} from './asserters.js'
 import {
   fileAssetIdPattern,
+  filePreviewImageFilenamePattern,
+  filePreviewImageIdPattern,
   imageAssetFilenamePattern,
   imageAssetIdPattern,
   pathPattern,
@@ -26,6 +28,12 @@ const exampleFileId = 'file-027401f31c3ac1e6d78c5d539ccd1beff72b9b11-pdf'
 const exampleImageId = 'image-027401f31c3ac1e6d78c5d539ccd1beff72b9b11-2000x3000-jpg'
 
 /**
+ * @internal
+ */
+const exampleFilePreviewImageId =
+  'image-027401f31c3ac1e6d78c5d539ccd1beff72b9b11-2000x3000-pdf-webp'
+
+/**
  * Parses a Sanity asset document ID into individual parts (type, id, extension, width/height etc)
  *
  * @param documentId - Document ID to parse into named parts
@@ -36,6 +44,9 @@ const exampleImageId = 'image-027401f31c3ac1e6d78c5d539ccd1beff72b9b11-2000x3000
 export function parseAssetId(documentId: string): SanityAssetIdParts {
   if (imageAssetIdPattern.test(documentId)) {
     return parseImageAssetId(documentId)
+  }
+  if (filePreviewImageIdPattern.test(documentId)) {
+    return parseFilePreviewImageAssetId(documentId)
   }
 
   if (fileAssetIdPattern.test(documentId)) {
@@ -84,6 +95,36 @@ export function parseImageAssetId(documentId: string): SanityImageAssetIdParts {
 }
 
 /**
+ * Parses a Sanity file preview image asset document ID into individual parts (type, id, extension, width, height, fileAssetExtension)
+ *
+ * @param documentId - Image asset document ID to parse into named parts
+ * @returns Object of named properties
+ * @public
+ * @throws If document ID invalid
+ */
+export function parseFilePreviewImageAssetId(
+  documentId: string,
+): SanityImageAssetIdParts & {fileAssetExtension: string} {
+  const [, assetId, dimensionString, fileAssetExtension, extension] = documentId.split('-')
+  const [width, height] = (dimensionString || '').split('x').map(Number)
+
+  if (
+    !assetId ||
+    !dimensionString ||
+    !extension ||
+    !fileAssetExtension ||
+    !(width > 0) ||
+    !(height > 0)
+  ) {
+    throw new Error(
+      `Malformed asset ID '${documentId}'. Expected an id like "${exampleFilePreviewImageId}".`,
+    )
+  }
+
+  return {type: 'image', assetId, width, height, extension, fileAssetExtension}
+}
+
+/**
  * Parses a Sanity asset filename into individual parts (type, id, extension, width, height)
  *
  * @param filename - Filename to parse into named parts
@@ -96,9 +137,11 @@ export function parseAssetFilename(filename: string): SanityAssetIdParts {
   if (!isValidFilename(file)) {
     throw new Error(`Invalid image/file asset filename: ${filename}`)
   }
+  const isImageType =
+    imageAssetFilenamePattern.test(file) || filePreviewImageFilenamePattern.test(file)
 
   try {
-    const type = imageAssetFilenamePattern.test(file) ? 'image' : 'file'
+    const type = isImageType ? 'image' : 'file'
     const assetId = file.replace(/\.([a-z0-9+]+)$/i, '-$1')
     return parseAssetId(`${type}-${assetId}`)
   } catch (err) {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -8,6 +8,7 @@ import {
 import {
   cdnUrl,
   fileAssetFilenamePattern,
+  filePreviewImageFilenamePattern,
   imageAssetFilenamePattern,
   pathPattern,
 } from './constants.js'
@@ -211,7 +212,11 @@ export const tryGetUrlFilename = getForgivingResolver(getUrlFilename)
  * @public
  */
 export function isValidFilename(filename: string): boolean {
-  return fileAssetFilenamePattern.test(filename) || imageAssetFilenamePattern.test(filename)
+  return (
+    fileAssetFilenamePattern.test(filename) ||
+    imageAssetFilenamePattern.test(filename) ||
+    filePreviewImageFilenamePattern.test(filename)
+  )
 }
 
 /**

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -109,6 +109,20 @@ test('parseAssetFilename(): returns object of named image properties if legacy f
   `)
 })
 
+test('parseAssetFilename(): returns object of named image properties if file preview image', () => {
+  expect(parseAssetFilename('90ffd2359008d82298821d16b21778c5c39aec36-1024x1024-pdf.webp'))
+    .toMatchInlineSnapshot(`
+    {
+      "assetId": "90ffd2359008d82298821d16b21778c5c39aec36",
+      "extension": "webp",
+      "fileAssetExtension": "pdf",
+      "height": 1024,
+      "type": "image",
+      "width": 1024,
+    }
+  `)
+})
+
 test.each([
   'https://cdn.sanity.io/images/espenhov/diary/756e4bd9c0a04ada3d3cc396cf81f1c433b07870-5760x3840.jpg/vanity-filename.jpg',
   'https://cdn.sanity.staging/images/espenhov/diary/756e4bd9c0a04ada3d3cc396cf81f1c433b07870-5760x3840.jpg/vanity-filename.jpg',


### PR DESCRIPTION
### Description

As we introduce a third type of file and ID pattern in the Sanity asset universe (file asset image previews), it would be beneficial to continue relying on this library for testing, extracting, and verifying the IDs and filenames for such resources.

Normal image:
`eca53d85ec83704801ead6c8be368fd377f8aaef-200x500.webp`

File asset preview image:
`eca53d85ec83704801ead6c8be368fd377f8aaef-200x500-pdf.webp`

Note the extra file extension addition before the image extension, representing the asset's file type/extension for which the preview image is for.

This PR builds support for these string patterns, so that one can do:

```js
const asset = parseAssetFilename('eca53d85ec83704801ead6c8be368fd377f8aaef-200x500-pdf.webp')
```
```js
{
  type: 'image',
  assetId: '90ffd2359008d82298821d16b21778c5c39aec36',
  width: 1024,
  height: 1024,
  extension: 'webp',
  fileAssetExtension: 'pdf'
}
```

(This would throw an error previously.)

It introduces one new public function:
```ts
parseFilePreviewImageAssetId(id: string)
```

And builds support into these existing public functions:

```
parseAssetId
parseAssetFilename
isValidFilename
```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is it OK to bring this knowledge into this library?

Could it mess up something? I have made sure we always test the image first, so I don't think so?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Added unit tests.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
